### PR TITLE
Pm 663 control dump scratch area location

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -47,7 +47,7 @@ for i in {1..5}; do
 		}
 	fi
 
-	mkdir -p "/pg_dump"
+	mkdir "/pg_dump" || exit 1
 
 	# Dump individual databases directly to restic repository.
 	dblist=$(psql -d postgres -q -t -c "SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'rdsadmin', 'template0', 'template1')")

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,12 +2,14 @@
 
 set -e
 
+ok=1
 for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY RESTIC_PASSWORD RESTIC_REPOSITORY; do
 	eval [[ -z \${$var+1} ]] && {
 		>&2 echo "ERROR: Missing required environment variable: $var"
-		exit 1
+		ok=
 	}
 done
+[ $ok ] || exit 1
 
 if ! restic unlock; then
 	restic init


### PR DESCRIPTION
Primarily let $PGDUMP_BACKUP_AREA override the default /pg_dump scratch area.

Other small changes.